### PR TITLE
fix: set exitCode when generation with jsdoc fails

### DIFF
--- a/packages/scriptappy-from-jsdoc/src/cli.js
+++ b/packages/scriptappy-from-jsdoc/src/cli.js
@@ -140,7 +140,9 @@ if (require.main === module) {
       try {
         runWithJSDoc(files);
       } catch (e) {
+        process.exitCode = 1;
         console.log(e.stack);
+        throw e;
       }
     })();
   }


### PR DESCRIPTION
Also throw the exception which enables handling it from the outside if wanted