### PR TITLE
fix(from-jsdoc): increase maxBuffer size to 10MiB

### DIFF
--- a/packages/from-jsdoc/lib/index.js
+++ b/packages/from-jsdoc/lib/index.js
@@ -8,6 +8,8 @@ const cp = require('child_process');
 
 const { generate } = require('./transformer.js');
 
+const SPAWN_PROCESS_BUFFER_SIZE = 10240 * 1024; // 10MiB
+
 const getJsDocConfig = (files, config) => {
   const cfg = {
     source: {
@@ -31,7 +33,10 @@ const generateJSDoc = jsDocConfig => {
   const temp = path.join(__dirname, `${jsdocConfigFilename}.json`);
   fs.writeFileSync(temp, JSON.stringify(jsDocConfig, null, 2));
   try {
-    s = cp.execSync(`npx jsdoc -c ./${jsdocConfigFilename}.json -p -X`, { cwd: __dirname });
+    s = cp.execSync(`npx jsdoc -c ./${jsdocConfigFilename}.json -p -X`, {
+      cwd: __dirname,
+      maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
+    });
   } catch (e) {
     throw new Error(e.stderr.toString());
   } finally {


### PR DESCRIPTION
## Summary

Fixes jsdoc generation for large docs, on node v12 and above, this is the end output:

```
(node:85145) UnhandledPromiseRejectionWarning: Error: Could not generate JSDoc
    at runWithJSDoc (/Users/project/node_modules/scriptappy-from-jsdoc/src/cli.js:109:11)
    at withJSDoc (/Users/project/node_modules/scriptappy-from-jsdoc/src/cli.js:135:7)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:85145) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:85145) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Generating specification for my-api
WARNING: The @private tag does not permit a value; the value will be ignored. File: my-api.js, line: 37
WARNING: The @private tag does not permit a value; the value will be ignored. File: my-api.js, line: 44
```

After applying this patch:

```
Generating specification for my-api
WARNING: The @private tag does not permit a value; the value will be ignored. File: my-api.js, line: 37
WARNING: The @private tag does not permit a value; the value will be ignored. File: my-api.js, line: 44
```

## Docs

- https://nodejs.org/docs/latest-v12.x/api/child_process.html#child_process_child_process_execsync_command_options