### PR TITLE
fix(from-jsdoc): increase max std-buffer to 10mb

### DIFF
--- a/packages/from-jsdoc/lib/index.js
+++ b/packages/from-jsdoc/lib/index.js
@@ -31,7 +31,10 @@ const generateJSDoc = jsDocConfig => {
   const temp = path.join(__dirname, `${jsdocConfigFilename}.json`);
   fs.writeFileSync(temp, JSON.stringify(jsDocConfig, null, 2));
   try {
-    s = cp.execSync(`npx jsdoc -c ./${jsdocConfigFilename}.json -p -X`, { cwd: __dirname });
+    s = cp.execSync(`npx jsdoc -c ./${jsdocConfigFilename}.json -p -X`, {
+      cwd: __dirname,
+      maxBuffer: 1024 * 1024 * 10,
+    });
   } catch (e) {
     throw new Error(e.stderr.toString());
   } finally {


### PR DESCRIPTION
#6 
**Issue**
The from-jsdoc call has issues for larger codebases (my assumption). Changing the maxBuffer on the execSync call from the default 1024*1024 to a higher value resolves this.

closes #6 