### PR TITLE
fix: support for unordered lists

### DIFF
--- a/packages/from-jsdoc/lib/collect-nest.js
+++ b/packages/from-jsdoc/lib/collect-nest.js
@@ -1,7 +1,9 @@
 function collectAndNest({ list, asArray }, cfg, opts, entity) {
   const paramMap = {};
   const res = [];
-  (list || []).forEach(par => {
+  (list || []).sort((a,b)=>{ // sort the list by "parents" first
+    return (a && b) ? a.name.split('.').length-b.name.split('.').length : 0;
+  }).forEach(par => {
     const s = par.name.split('.');
     let parent = paramMap;
     let i = 0;


### PR DESCRIPTION
unordered nested options don't get reflected in the spec. ex:
```
/**
 * @prop {string} [options.clearselections] - clearselections - Clears all selections made in the app before applying bookmarks and selections
 * @prop {string} [options.developer] - developer - enables developer mode in qlik-sense. {@experimental}
 * @prop {string} [options] - Add option definitions in addition to the Base URL.
 * /
```
doesn't work: "parent" "options" prop is after it's nested props

The fix consist on sorting the list by "parents" first - to avoid overwriting the resulted object